### PR TITLE
fixed mistake on the Ironclad asset

### DIFF
--- a/ironsworn_assets.json
+++ b/ironsworn_assets.json
@@ -934,13 +934,13 @@
         "Fields": [
           {
             "Name": "Armor",
-            "ActiveText": "Lightly Geared",
+            "ActiveText": "Lightly Armored",
             "InactiveText": "-",
             "IsActive": false
           },
           {
             "Name": "Armor",
-            "ActiveText": "Armored for War",
+            "ActiveText": "Geared for War",
             "InactiveText": "-",
             "IsActive": false
           }


### PR DESCRIPTION
The Track labels on the **Ironclad** Asset were incorrect. Instead of `Lightly Geared` it should read `Lightly Armored` and instead of `Armored for War` it should be `Geared for War`