### PR TITLE
Fix faction name templates

### DIFF
--- a/source_data/starforged/oracles/factions.yaml
+++ b/source_data/starforged/oracles/factions.yaml
@@ -956,27 +956,27 @@ oracles:
                         part_of_speech: proper_noun
                 min: 1
                 max: 40
-                text: '[Legacy](id:starforged/oracles/factions/legacy) [Affiliation](id:starforged/oracles/factions/affiliation)'
+                text: '[Legacy](id:starforged/oracles/factions/name/legacy) [Affiliation](id:starforged/oracles/factions/name/affiliation)'
                 template:
-                  text: '{{text:starforged/oracles/factions/legacy}} {{text:starforged/oracles/factions/affiliation}}'
+                  text: '{{text:starforged/oracles/factions/name/legacy}} {{text:starforged/oracles/factions/name/affiliation}}'
               - <<: *i18n.template.result.proper_noun
                 min: 41
                 max: 55
-                text: '[Legacy](id:starforged/oracles/factions/legacy) [Identity](id:starforged/oracles/factions/identity)'
+                text: '[Legacy](id:starforged/oracles/factions/name/legacy) [Identity](id:starforged/oracles/factions/name/identity)'
                 template:
-                  text: '{{text:starforged/oracles/factions/legacy}} {{text:starforged/oracles/factions/identity}}'
+                  text: '{{text:starforged/oracles/factions/name/legacy}} {{text:starforged/oracles/factions/name/identity}}'
               - <<: *i18n.template.result.proper_noun
                 min: 56
                 max: 70
-                text: '[Identity](id:starforged/oracles/factions/identity) *of the* [Legacy](id:starforged/oracles/factions/legacy) [Affiliation](id:starforged/oracles/factions/affiliation)'
+                text: '[Identity](id:starforged/oracles/factions/name/identity) *of the* [Legacy](id:starforged/oracles/factions/name/legacy) [Affiliation](id:starforged/oracles/factions/name/affiliation)'
                 template:
-                  text: '{{text:starforged/oracles/factions/identity}} of the {{text:starforged/oracles/factions/legacy}} {{text:starforged/oracles/factions/affiliation}}'
+                  text: '{{text:starforged/oracles/factions/name/identity}} of the {{text:starforged/oracles/factions/name/legacy}} {{text:starforged/oracles/factions/name/affiliation}}'
               - <<: *i18n.template.result.proper_noun
                 min: 71
                 max: 100
-                text: '[Affiliation](id:starforged/oracles/factions/affiliation) *of the* [Legacy](id:starforged/oracles/factions/legacy) [Identity](id:starforged/oracles/factions/identity)'
+                text: '[Affiliation](id:starforged/oracles/factions/name/affiliation) *of the* [Legacy](id:starforged/oracles/factions/name/legacy) [Identity](id:starforged/oracles/factions/name/identity)'
                 template:
-                  text: '{{text:starforged/oracles/factions/affiliation}} of the {{text:starforged/oracles/factions/legacy}} {{text:starforged/oracles/factions/identity}}'
+                  text: '{{text:starforged/oracles/factions/name/affiliation}} of the {{text:starforged/oracles/factions/name/legacy}} {{text:starforged/oracles/factions/name/identity}}'
           legacy:
             name: Legacy
             _source: *CollectionSource


### PR DESCRIPTION
The faction name templates had incorrect paths to the component oracles.