### PR TITLE
Add table references for Ask the Oracle move

### DIFF
--- a/source_data/classic/moves.yaml
+++ b/source_data/classic/moves.yaml
@@ -1464,3 +1464,5 @@ moves:
           Small Chance   | 91 or greater
 
           On a match, an extreme result or twist has occurred.
+
+          {{table_columns>move:classic/fate/ask_the_oracle}}

--- a/source_data/starforged/moves.yaml
+++ b/source_data/starforged/moves.yaml
@@ -2313,6 +2313,8 @@ moves:
           Almost Certain | 90 or less
 
           On a match, envision an extreme result or twist.
+
+          {{table_columns>move:starforged/fate/ask_the_oracle}}
         _source:
           <<: *Source
           page: 229


### PR DESCRIPTION
Adding references to the "Ask the Oracle" tables to the description of the move itself, based on how the "Delve the Depths" move does it.

For example in Iron Vault, this should make the oracle tables appear in the move description in the sidebar, and allow a user to directly roll on them: 
<img width="460" height="1057" alt="image" src="https://github.com/user-attachments/assets/3761711d-aa15-4968-9319-5f1401785387" />
